### PR TITLE
fix(user-password-md5): fix md5 check on password field.

### DIFF
--- a/modules/pgbouncer_cloud_init/main.tf
+++ b/modules/pgbouncer_cloud_init/main.tf
@@ -1,5 +1,5 @@
 locals {
-  users    = [for u in var.users : ({ name = u.name, password = substr(u.password, 0, 2) == "md5" ? u.password : "md5${md5("${u.password}${u.name}")}" })]
+  users    = [for u in var.users : ({ name = u.name, password = substr(u.password, 0, 3) == "md5" ? u.password : "md5${md5("${u.password}${u.name}")}" })]
   admins   = [for u in var.users : u.name if lookup(u, "admin", false) == true]
   userlist = templatefile("${path.module}/templates/userlist.txt.tmpl", { users = local.users })
   cloud_config = templatefile(


### PR DESCRIPTION
The second field to substr function is for number of characters to extract. The original function only extracted 2 characters so it’ll never compare true to “md5” which is 3 characters. 

Signed-off-by: Isaac Chong <isaac@flexnode.com>